### PR TITLE
Update devDependencies, bump version to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
-    "cz-conventional-changelog": "^1.1.5",
-    "istanbul": "^0.4.2",
-    "jscs": "^2.11.0",
-    "jshint": "^2.9.1",
-    "mocha": "^2.4.5",
-    "posthtml": "^0.8.5",
+    "cz-conventional-changelog": "^1.1.6",
+    "istanbul": "^0.4.3",
+    "jscs": "^3.0.3",
+    "jshint": "^2.9.2",
+    "mocha": "^2.5.3",
+    "posthtml": "^0.8.7",
     "version-bump-prompt": "^1.5.2"
   },
   "peerDependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthtml-head-elements",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Build HTML head elements from a JSON file",
   "main": "index.js",
   "devDependencies": {


### PR DESCRIPTION
Updates outdated `devDependencies` in `package.json` and bumps `version` to `0.5.1`. Changes pass `npm run test`.
